### PR TITLE
Update SHA1Utils.java

### DIFF
--- a/mykit-data-common/src/main/java/io/mykit/data/common/utils/SHA1Utils.java
+++ b/mykit-data-common/src/main/java/io/mykit/data/common/utils/SHA1Utils.java
@@ -48,6 +48,6 @@ public class SHA1Utils {
             return null;
         }
         // base64加密
-        return new sun.misc.BASE64Encoder().encode(sha1);
+        return java.util.Base64.getEncoder().encodeToString(sha1);
     }
 }


### PR DESCRIPTION
调整base64加密为java.util包实现，解决openjdk下编译报错的问题。
解决issue:https://github.com/binghe001/mykit-data/issues/5